### PR TITLE
Bug Fix - 404 on Drug Suggestions

### DIFF
--- a/muler/templates/result.html
+++ b/muler/templates/result.html
@@ -9,7 +9,7 @@
       <p>Showing results for '{{ suggestions[0] }}'.</p>
       <p>Did you mean: </p>
         {% for i in suggestions[1:] %}
-          <a href='/{{ i }}'>{{ i }}</a>
+          <a href='/search/{{ i }}'>{{ i }}</a>
         {% endfor %}
     {% endif %}
 


### PR DESCRIPTION
This pull request closes issue #10.

The current `result.html` results in a 404, when clicking on Drug Suggestions. This change will prefix the URL path with `search`, e.g. as `.../search/drugsuggestion` and redirect the user to the suggested drug page.

![image](https://user-images.githubusercontent.com/11654917/204955220-2e9e3a10-4bfb-4372-b9c8-f4129819ea00.png)
